### PR TITLE
Repair several bugs (array(), adjoint(), createDeterminant())

### DIFF
--- a/src/pallav/Matrix/Matrix.java
+++ b/src/pallav/Matrix/Matrix.java
@@ -35,9 +35,9 @@ public class Matrix {
 	 * @return new Matrix
 	 */
 	public static Matrix array(int[][] b) {
-		float[][] c = new float[b[0].length][b.length];
-		for (int i = 0; i < b[0].length; i++) {
-			for (int j = 0; j < b.length; j++) {
+		float[][] c = new float[b.length][b[0].length];
+		for (int i = 0; i < b.length; i++) {
+			for (int j = 0; j < b[0].length; j++) {
 				c[i][j] = (float) b[i][j];
 			}
 		}

--- a/src/pallav/Matrix/Matrix.java
+++ b/src/pallav/Matrix/Matrix.java
@@ -458,7 +458,7 @@ public class Matrix {
 	 * @return Matrix
 	 */
 	public static Matrix adjoint(Matrix a) {
-		return new Matrix(Matrix.adjoint(a).array);
+		return Matrix.adjoint(a.array);
 	}
 
 	/**

--- a/src/pallav/Matrix/Matrix.java
+++ b/src/pallav/Matrix/Matrix.java
@@ -484,7 +484,7 @@ public class Matrix {
 	 */
 	static float createDeterminant(Matrix mat, int n) {
 		float[][] A = mat.array;
-		int D = 0;
+		float D = 0;
 		if (n == 1) {
 			return A[0][0];
 		}


### PR DESCRIPTION
Commit 369de76

See more details in https://github.com/pallav12/matrixMath-for-processing/issues/1

Some test code (from that issue):
```
int[][] data = { {1, 2} };
Matrix i = Matrix.array(data);
Matrix.print(i);
```
This causes an ArrayIndexOutOfBoundsException