### PR TITLE
Change 'copy()' to do a deep copy

### DIFF
--- a/src/pallav/Matrix/Matrix.java
+++ b/src/pallav/Matrix/Matrix.java
@@ -179,14 +179,19 @@ public class Matrix {
 	}
 
 	/**
-	 * copy a Matrix
+	 * make a deep copy of a Matrix
 	 * 
 	 * @param a Matrix
 	 * @return b Matrix
 	 */
 	public static Matrix copy(Matrix a) {
-		float[][] arr = a.array.clone();
-		return new Matrix(arr);
+		double[][] c = new double[a.array.length][a.array[0].length];
+		for (int i = 0; i < a.array.length; i++) {
+			for (int j = 0; j < a.array[0].length; j++) {
+				c[i][j] = a.array[i][j];
+			}
+		}
+		return new Matrix(c);
 
 	}
 


### PR DESCRIPTION
Existing implementation did a shallow copy. That may be the intent, but in my view not very useful since an assignment of one matrix to another will do the trick as well.

Feel free to reject this (as it may break existing usage); but then it may be desirable to offer an additional deepCopy() function.

Some test code to show the difference:
```
void test_copy() {
  double[][] data = { {1, 2, 3}, {2, -1, 0} };
  Matrix orig = Matrix.array(data);
  Matrix deepcopy = Matrix.copy(orig);
  Matrix shallowcopy = orig;
  Matrix.print("Orig         ", orig);
  Matrix.print("Copy deep    ", deepcopy);
  Matrix.print("Copy shallow ", shallowcopy);
  
  orig.array[0][0] = -1;
  println("Changed orig[0][0] to -1");
  Matrix.print("Orig         ", orig);
  Matrix.print("Copy deep    ", deepcopy);
  Matrix.print("Copy shallow ", shallowcopy);
}
```

Note:: I have refrained from adding these kinds of test snippets to processing_library_example.pde, since that does not really belong there. Maybe create a dedicated test_pallav12_matrix.pde.